### PR TITLE
chore(README): add amendment for whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2550,22 +2550,24 @@ We use 4 spaces instead of the recommended 2. See [18.1](#18.1).
 
 ### Whitespace (Functions)
 
-**Always** put a space before the opening parentheses of a function expression or declaration, regardless of the function being named or not. 
+We **prefer** to always put a space before the opening parentheses of a function expression or declaration, regardless of the function being named or not. 
+
+If you choose to not use a space, a warning will be thrown by our linter. It's OK to not use a space, but it's not recommended.
 
 ```js
-// bad
+// kind-of-bad
 function() {}
 
 // good
 function () {}
 
-// bad
+// kind-of-bad
 const foo = function() {}
 
 // good
 const foo = function () {}
 
-// bad
+// kind-of-bad
 function bar() {}
 
 // good

--- a/README.md
+++ b/README.md
@@ -2547,3 +2547,29 @@ We use 4 spaces instead of the recommended 2. See [18.1](#18.1).
 ### Trailing Commas
 
 **Hell, NO.** We're not going for trailing commas. See [19.2](#19.2).
+
+### Whitespace (Functions)
+
+**Always** put a space before the opening parentheses of a function expression or declaration, regardless of the function being named or not. 
+
+```js
+// bad
+function() {}
+
+// good
+function () {}
+
+// bad
+const foo = function() {}
+
+// good
+const foo = function () {}
+
+// bad
+function bar() {}
+
+// good
+function bar () {}
+```
+
+This amendment changes [18.3](#18.3) & [7.11](#7.11) a bit. 


### PR DESCRIPTION
We want to **recommend** to always put a space before the opening parentheses of a function declaration or expression.
